### PR TITLE
Attack CRD implementation Closes #5

### DIFF
--- a/CRD/attack-crd.yaml
+++ b/CRD/attack-crd.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: attacks.hu.elte.inf.psac.mdc           # The full name of the CRD
+spec:
+  group: hu.elte.inf.psac.mdc                  # The API group for the CRD
+  versions:
+    - name: alpha
+      served: true                             # Specifies that this version is served by the API
+      storage: true                            # Marks this version as the storage version
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                target:
+                  type: object
+                  properties:
+                    matchLabels:
+                      type: object             # Target selection via labels
+                      additionalProperties:
+                        type: string           # Allow arbitrary labels as strings
+                    containers:
+                      type: string             # Regex for container name matching
+                attack:
+                  type: array                  # Array of attack specifications
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string           # Name of the attack
+                      spec:
+                        type: object
+                        properties:
+                          surface:
+                            type: string       # Specifies an attack surface like exec or port
+                            enum:              
+                              - "exec"
+                              - "port"
+                          kind:
+                            type: string       # Specifies the kind of attack
+                            enum:
+                              - "xrp-mine"
+  scope: Cluster
+  names:
+    plural: attacks                            # Plural form of the resource
+    singular: attack                           # Singular form of the resource
+    kind: Attack                               # The CamelCase name for the custom resource
+    shortNames:
+      - atk                                    # Optional shorthand for quick access

--- a/CRD/attack-example.yaml
+++ b/CRD/attack-example.yaml
@@ -1,0 +1,20 @@
+apiVersion: hu.elte.inf.psac.mdc/alpha
+kind: Attack
+metadata:
+  name: example-attack
+spec:
+  target:
+    matchLabels:
+      app: mongodb
+      environment: production
+      tier: backend
+    containers: "mongo.*"
+  attack:
+    - name: xrp-mine-exec
+      spec:
+        surface: exec
+        kind: xrp-mine
+    - name: xrp-mine-port
+      spec:
+        surface: port
+        kind: xrp-mine


### PR DESCRIPTION
Didn't find any method to  "import" or reference the matchLabels schema from native Kubernetes resources like Deployment or Service. However, we can replicate the matchLabels structure to mimic how it’s used in native resources.